### PR TITLE
Add FullNode's get_coin_record_by_name RPC

### DIFF
--- a/src/FullNode.ts
+++ b/src/FullNode.ts
@@ -2,6 +2,7 @@ import {
   BlocksResponse,
   BlockchainStateResponse,
   CoinResponse,
+  CoinRecordResponse,
   NetspaceResponse,
   BlockResponse,
   BlockRecordResponse,
@@ -100,6 +101,12 @@ class FullNode extends RpcClient {
       start_height: startHeight,
       end_height: endHeight,
       include_spent_coins: false,
+    });
+  }
+
+  public async getCoinRecordByName(name: string): Promise<CoinRecordResponse> {
+    return this.request<CoinRecordResponse>("get_coin_record_by_name", {
+      name,
     });
   }
 

--- a/src/types/FullNode/RpcResponse.ts
+++ b/src/types/FullNode/RpcResponse.ts
@@ -33,6 +33,9 @@ export interface CoinResponse extends RpcResponse {
     coin_records: Array<CoinRecord>;
 }
 
+export interface CoinRecordResponse extends RpcResponse {
+    coin_record: CoinRecord;
+}
 export interface AdditionsAndRemovalsResponse extends RpcResponse {
     additions: Array<CoinRecord>;
     removals: Array<CoinRecord>;


### PR DESCRIPTION
This PR adds the RPC get_coin_record_by_name (https://github.com/Chia-Network/chia-blockchain/blob/main/chia/rpc/full_node_rpc_api.py#L353)
