### PR TITLE
Add missing parameter to getTransactions

### DIFF
--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -166,10 +166,10 @@ class Wallet extends RpcClient {
     return transaction;
   }
 
-  public async getTransactions(walletId: string): Promise<Transaction[]> {
+  public async getTransactions(walletId: string, limit: number): Promise<Transaction[]> {
     const { transactions } = await this.request<TransactionsResponse>(
       "get_transactions",
-      { wallet_id: walletId }
+      { wallet_id: walletId, end: limit }
     );
 
     return transactions;
@@ -178,7 +178,7 @@ class Wallet extends RpcClient {
   public async getNextAddress(walletId: string): Promise<string> {
     const { address } = await this.request<NextAddressResponse>(
       "get_next_address",
-      { wallet_id: walletId ,new_address: true}
+      { wallet_id: walletId, new_address: true}
     );
 
     return address;

--- a/test/wallet.spec.ts
+++ b/test/wallet.spec.ts
@@ -179,6 +179,15 @@ describe("Wallet", () => {
       expect(await wallet.getTransactions("fakeWalletId")).toEqual("success");
     });
 
+    it("calls get_transactions with limit=1000", async () => {
+      nock("https://localhost:8555")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_transactions", { wallet_id: "fakeWalletId", end: 1000 })
+        .reply(200, { transactions: "success" });
+
+      expect(await wallet.getTransactions("fakeWalletId", 1000)).toEqual("success");
+    });
+
     it("calls get_next_address", async () => {
       nock("https://localhost:8555")
         .defaultReplyHeaders({ "access-control-allow-origin": "*" })


### PR DESCRIPTION
Adds the `limit` parameter to getTransactions, which gives the limit of how many transactions should be shown (important because the RPC `get_transactions` only shows 50 by default).

Also, I was wondering if you ran the Chia Explorer or knew who did, since I have a very simple feature suggestion for the explorer (has to do with an improvement to the miscellaneous transaction label) and haven't found any contact information on the website. Thanks!