### PR TITLE
Add Conversion Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
-    "yaml": "2.0.0-5"
+    "yaml": "2.0.0-5",
+    "chia-utils": "^1.0.2"
   },
   "jest": {
     "roots": [

--- a/src/FullNode.ts
+++ b/src/FullNode.ts
@@ -13,6 +13,7 @@ import { ChiaOptions, RpcClient } from "./RpcClient";
 import { Block } from "./types/FullNode/Block";
 import { CertPath } from "./types/CertPath";
 import { getChiaConfig, getChiaFilePath } from "./ChiaNodeUtils";
+import { address_to_puzzle_hash, puzzle_hash_to_address, get_coin_info } from "chia-utils";
 
 const chiaConfig = getChiaConfig();
 const defaultProtocol = "https";
@@ -119,6 +120,19 @@ class FullNode extends RpcClient {
         header_hash: hash,
       }
     );
+  }
+  
+  /* https://github.com/CMEONE/chia-utils */
+  public addressToPuzzleHash(address: string): string {
+    return address_to_puzzle_hash(address);
+  }
+  
+  public puzzleHashToAddress(puzzleHash: string): string {
+    return puzzle_hash_to_address(puzzleHash);
+  }
+  
+  public getCoinInfo(parentCoinInfo: string, puzzleHash: string, amount: number): string {
+    return get_coin_info(parentCoinInfo, puzzleHash, amount / 1000000000000);
   }
 }
 

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -18,6 +18,7 @@ import {
 import { Transaction } from "./types/Wallet/Transaction";
 import { WalletBalance } from "./types/Wallet/WalletBalance";
 import { WalletInfo } from "./types/Wallet/WalletInfo";
+import { address_to_puzzle_hash, puzzle_hash_to_address, get_coin_info } from "chia-utils";
 
 const chiaConfig = getChiaConfig();
 const defaultProtocol = "https";
@@ -205,6 +206,19 @@ class Wallet extends RpcClient {
 
   public async createBackup(filePath: string): Promise<{}> {
     return this.request<{}>("create_backup", { file_path: filePath });
+  }
+  
+  /*  */
+  public addressToPuzzleHash(address: string): string {
+    return address_to_puzzle_hash(address);
+  }
+  
+  public puzzleHashToAddress(puzzleHash: string): string {
+    return puzzle_hash_to_address(puzzleHash);
+  }
+  
+  public getCoinInfo(parentCoinInfo: string, puzzleHash: string, amount: number): string {
+    return get_coin_info(parentCoinInfo, puzzleHash, amount / 1000000000000);
   }
 }
 

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -208,7 +208,7 @@ class Wallet extends RpcClient {
     return this.request<{}>("create_backup", { file_path: filePath });
   }
   
-  /*  */
+  /* https://github.com/CMEONE/chia-utils */
   public addressToPuzzleHash(address: string): string {
     return address_to_puzzle_hash(address);
   }


### PR DESCRIPTION
Adds conversion functions based on requests in issues:
- `public addressToPuzzleHash(address: string): string`
- `public puzzleHashToAddress(puzzleHash: string): string`
- `public getCoinInfo(parentCoinInfo: string, puzzleHash: string, amount: number): string`

Ported directly from `Chia-Network/chia-blockchain` into JavaScript at https://github.com/CMEONE/chia-utils (https://www.npmjs.com/package/chia-utils)

Added to `Wallet` and `FullNode` since applicable in both classes

