### PR TITLE
Add RPC calls for Farmer and Harvester 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,11 @@
 import { FullNode } from './src/FullNode';
 import { Wallet } from './src/Wallet';
+import { Harvester } from './src/Harvester';
 import { SharedCalls } from './src/SharedCalls'
 
 export {
     FullNode,
+    Harvester,
     Wallet,
     SharedCalls,
 };

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,12 @@
 import { FullNode } from './src/FullNode';
 import { Wallet } from './src/Wallet';
 import { Harvester } from './src/Harvester';
+import { Farmer } from './src/Farmer';
 import { SharedCalls } from './src/SharedCalls'
 
 export {
     FullNode,
+    Farmer,
     Harvester,
     Wallet,
     SharedCalls,

--- a/src/Farmer.ts
+++ b/src/Farmer.ts
@@ -1,0 +1,62 @@
+import { 
+  RewardTargetResponse,
+  SignagePointResponse,
+  SignagePointsResponse
+} from "./types/Farmer/RpcResponse";
+import { CertPath } from "./types/CertPath";
+import { getChiaConfig, getChiaFilePath } from "./ChiaNodeUtils";
+import { ChiaOptions, RpcClient } from "./RpcClient";
+import { RpcResponse } from "./types/RpcResponse";
+
+const chiaConfig = getChiaConfig();
+const defaultProtocol = "https";
+const defaultHostname = chiaConfig?.self_hostname || "localhost";
+const defaultPort = chiaConfig?.farmer.rpc_port || 8559;
+const defaultCaCertPath = chiaConfig?.private_ssl_ca.crt;
+const defaultCertPath = chiaConfig?.daemon_ssl.private_crt;
+const defaultCertKey = chiaConfig?.daemon_ssl.private_key;
+
+class Farmer extends RpcClient {
+  public constructor(options?: Partial<ChiaOptions> & CertPath) {
+    super({
+      protocol: options?.protocol || defaultProtocol,
+      hostname: options?.hostname || defaultHostname,
+      port: options?.port || defaultPort,
+      caCertPath: options?.caCertPath || getChiaFilePath(defaultCaCertPath),
+      certPath: options?.certPath || getChiaFilePath(defaultCertPath),
+      keyPath: options?.keyPath || getChiaFilePath(defaultCertKey),
+    });
+  }
+
+  public async getSignagePoint(
+    signagePointHash: string
+  ): Promise<SignagePointResponse> {
+    return this.request<SignagePointResponse>("get_signage_point", {
+      sp_hash: signagePointHash,
+    });
+  }
+
+  public async getSignagePoints(): Promise<SignagePointsResponse> {
+    return this.request<SignagePointsResponse>("get_signage_points", {});
+  }
+
+  public async getRewardTarget(
+    searchForPrivateKey: boolean
+  ): Promise<RewardTargetResponse> {
+    return this.request<RewardTargetResponse>("get_reward_targets", {
+      search_for_private_key: searchForPrivateKey,
+    });
+  }
+
+  public async setRewardTarget(
+    farmerTarget?: string,
+    poolTarget?: string
+  ): Promise<RpcResponse> {
+    return this.request<RpcResponse>("set_reward_targets", {
+      farmer_target: farmerTarget,
+      pool_target: poolTarget
+    });
+  }
+}
+
+export { Farmer };

--- a/src/Harvester.ts
+++ b/src/Harvester.ts
@@ -1,0 +1,67 @@
+import {
+  PlotDirectoriesResponse,
+  PlotsResponse
+} from "./types/Harvester/RpcResponse";
+import { CertPath } from "./types/CertPath";
+import { getChiaConfig, getChiaFilePath } from "./ChiaNodeUtils";
+import { ChiaOptions, RpcClient } from "./RpcClient";
+import { RpcResponse } from "./types/RpcResponse";
+
+const chiaConfig = getChiaConfig();
+const defaultProtocol = "https";
+const defaultHostname = chiaConfig?.self_hostname || "localhost";
+const defaultPort = chiaConfig?.harvester.rpc_port || 8560;
+const defaultCaCertPath = chiaConfig?.private_ssl_ca.crt;
+const defaultCertPath = chiaConfig?.daemon_ssl.private_crt;
+const defaultCertKey = chiaConfig?.daemon_ssl.private_key;
+
+class Harvester extends RpcClient {
+  public constructor(options?: Partial<ChiaOptions> & CertPath) {
+    super({
+      protocol: options?.protocol || defaultProtocol,
+      hostname: options?.hostname || defaultHostname,
+      port: options?.port || defaultPort,
+      caCertPath: options?.caCertPath || getChiaFilePath(defaultCaCertPath),
+      certPath: options?.certPath || getChiaFilePath(defaultCertPath),
+      keyPath: options?.keyPath || getChiaFilePath(defaultCertKey),
+    });
+  }
+
+  public async getPlots(): Promise<PlotsResponse> {
+    return this.request<PlotsResponse>("get_plots", {});
+  }
+
+  public async refreshPlots(): Promise<RpcResponse> {
+    return this.request<RpcResponse>("refresh_plots", {});
+  }
+
+  public async deletePlot(
+    fileName: string
+  ): Promise<RpcResponse> {
+    return this.request<RpcResponse>("delete_plot", {
+      filename: fileName
+    });
+  }
+
+  public async addPlotDirectory(
+    dirName: string
+  ): Promise<RpcResponse> {
+    return this.request<RpcResponse>("add_plot_directory", {
+      dirname: dirName
+    });
+  }
+
+  public async getPlotDirectories(): Promise<PlotDirectoriesResponse> {
+    return this.request<PlotDirectoriesResponse>("get_plot_directories", {});
+  }
+
+  public async removePlotDirectory(
+    dirName: string
+  ): Promise<RpcResponse> {
+    return this.request<RpcResponse>("remove_plot_directory", {
+      dirname: dirName
+    });
+  }
+}
+
+export { Harvester };

--- a/src/types/Farmer/ProofOfSpace.ts
+++ b/src/types/Farmer/ProofOfSpace.ts
@@ -1,0 +1,4 @@
+export interface ProofOfSpace {
+  plot_identifier: string;
+  proof: string;
+}

--- a/src/types/Farmer/RpcResponse.ts
+++ b/src/types/Farmer/RpcResponse.ts
@@ -1,0 +1,23 @@
+import { ProofOfSpace } from '../FullNode/ProofOfSpace';
+import { RpcResponse } from '../RpcResponse';
+import { SignagePoint } from './SignagePoint';
+
+export interface SignagePointResponse extends RpcResponse {
+    signage_point: SignagePoint;
+    proofs: ProofOfSpace[];
+}
+
+export interface SignagePointsResponse extends RpcResponse {
+    signage_points: {
+        signage_point: SignagePoint;
+        proofs: ProofOfSpace[];
+    }[];
+}
+
+export interface RewardTargetResponse extends RpcResponse {
+    farmer_target: string;
+    pool_target: string;
+    have_farmer_sk?: boolean;
+    have_pool_sk?: boolean
+}
+

--- a/src/types/Farmer/SignagePoint.ts
+++ b/src/types/Farmer/SignagePoint.ts
@@ -1,0 +1,8 @@
+export interface SignagePoint {
+  challenge_hash: string;
+  challenge_chain_sp: string;
+  reward_chain_sp: string;
+  difficulty: number;
+  sub_slot_iters: number;
+  signage_point_index: number;
+}

--- a/src/types/Harvester/Plot.ts
+++ b/src/types/Harvester/Plot.ts
@@ -1,0 +1,10 @@
+export interface Plot {
+    file_size: number;
+    filename: string;
+    'plot-seed': string;
+    plot_public_key: string;
+    pool_contract_puzzle_hash: string;
+    pool_public_key: string;
+    size: number;
+    time_modified: number;
+}

--- a/src/types/Harvester/RpcResponse.ts
+++ b/src/types/Harvester/RpcResponse.ts
@@ -1,0 +1,12 @@
+import { RpcResponse } from '../RpcResponse';
+import { Plot } from './Plot';
+
+export interface PlotsResponse extends RpcResponse {
+    failed_to_open_filenames: string[];
+    not_found_filenames: string[];
+    plots: Plot[];
+}
+
+export interface PlotDirectoriesResponse extends RpcResponse {
+    directories: string[];
+}

--- a/test/farmer.spec.ts
+++ b/test/farmer.spec.ts
@@ -1,0 +1,54 @@
+import * as nock from "nock";
+import { Farmer } from "../index";
+
+jest.mock("fs");
+jest.mock("yaml");
+
+describe("Farmer", () => {
+  describe("RPC calls", () => {
+    const farmer = new Farmer({
+      caCertPath: "/dev/null/cert.crt",
+      certPath: "/dev/null/cert.crt",
+      keyPath: "/dev/null/cert.key",
+    });
+
+    it("calls get_signage_point", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_signage_point", { sp_hash: "fakeSpHash" })
+        .reply(200, "success");
+
+      expect(await farmer.getSignagePoint("fakeSpHash")).toEqual("success");
+    });
+
+    it("calls get_signage_points", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_signage_points")
+        .reply(200, "success");
+
+      expect(await farmer.getSignagePoints()).toEqual("success");
+    });
+
+    it("calls get_reward_targets", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_reward_targets", { search_for_private_key: true})
+        .reply(200, "success");
+
+      expect(await farmer.getRewardTarget(true)).toEqual("success");
+    });
+
+    it("calls set_reward_targets with farmer_target and pool_target in body", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/set_reward_targets", {
+          farmer_target: "fakeFarmerTarget",
+          pool_target: "fakePoolTarget",
+        })
+        .reply(200, "success");
+
+      expect(await farmer.setRewardTarget("fakeFarmerTarget", "fakePoolTarget")).toEqual("success");
+    });
+  });
+});

--- a/test/harvester.spec.ts
+++ b/test/harvester.spec.ts
@@ -1,0 +1,69 @@
+import * as nock from "nock";
+import { Harvester } from "../index";
+
+jest.mock("fs");
+jest.mock("yaml");
+
+describe("Harvester", () => {
+  describe("RPC calls", () => {
+    const harvester = new Harvester({
+      caCertPath: "/dev/null/cert.crt",
+      certPath: "/dev/null/cert.crt",
+      keyPath: "/dev/null/cert.key",
+    });
+
+    it("calls get_plots", async () => {
+      nock("https://localhost:8560")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_plots")
+        .reply(200, "success");
+
+      expect(await harvester.getPlots()).toEqual("success");
+    });
+
+    it("calls refresh_plots", async () => {
+      nock("https://localhost:8560")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/refresh_plots")
+        .reply(200, "success");
+
+      expect(await harvester.refreshPlots()).toEqual("success");
+    });
+
+    it("calls delete_plot with filename in body", async () => {
+      nock("https://localhost:8560")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/delete_plot", { filename: "fakePlotPath" })
+        .reply(200, "success");
+
+      expect(await harvester.deletePlot("fakePlotPath")).toEqual("success");
+    });
+
+    it("calls add_plot_directory with dirname in body", async () => {
+      nock("https://localhost:8560")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/add_plot_directory", { dirname: "fakeDirPath" })
+        .reply(200, "success");
+
+      expect(await harvester.addPlotDirectory("fakeDirPath")).toEqual("success");
+    });
+
+    it("calls get_plot_directories", async () => {
+      nock("https://localhost:8560")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_plot_directories")
+        .reply(200, "success");
+
+      expect(await harvester.getPlotDirectories()).toEqual("success");
+    });
+
+    it("calls remove_plot_directory with dirname in body", async () => {
+      nock("https://localhost:8560")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/remove_plot_directory", { dirname: "fakePlotPath" })
+        .reply(200, "success");
+
+      expect(await harvester.removePlotDirectory("fakePlotPath")).toEqual("success");
+    });
+  });
+});


### PR DESCRIPTION
Add RPC calls for Farmer and Harvester

- Farmer
   - `public async getSignagePoint(signagePointHash: string ): Promise<SignagePointResponse>`
   - `public async getSignagePoints(): Promise<SignagePointsResponse>`
   - `public async getRewardTarget(searchForPrivateKey: boolean): Promise<RewardTargetResponse>`
   - `public async setRewardTarget(farmerTarget?: string, poolTarget?: string): Promise<RpcResponse>`  
-  Harvester
   - `public async getPlots(): Promise<PlotsResponse>`
   - `public async refreshPlots(): Promise<RpcResponse>`
   - `public async deletePlot(fileName: string): Promise<RpcResponse>`
   - `public async addPlotDirectory(dirName: string): Promise<RpcResponse>`
   - `public async getPlotDirectories(): Promise<PlotDirectoriesResponse>`
   - `public async removePlotDirectory(dirName: string): Promise<RpcResponse>`

Taken from [ Chia-Network/chia-blockchain/wiki/RPC-Interfaces](https://github.com/Chia-Network/chia-blockchain/wiki/RPC-Interfaces) and code under `chia/rpc/farmer_rpc_api.py` and `chia/rpc/harvester_rpc_api.py`

Closes #2 