### PR TITLE
Add Pool RPC calls to Farmer

### DIFF
--- a/src/Farmer.ts
+++ b/src/Farmer.ts
@@ -1,4 +1,6 @@
 import { 
+  LoginLinkResponse,
+  PoolStateResponse,
   RewardTargetResponse,
   SignagePointResponse,
   SignagePointsResponse
@@ -55,6 +57,28 @@ class Farmer extends RpcClient {
     return this.request<RpcResponse>("set_reward_targets", {
       farmer_target: farmerTarget,
       pool_target: poolTarget
+    });
+  }
+
+  public async getPoolState(): Promise<PoolStateResponse> {
+    return this.request<PoolStateResponse>("get_pool_state", {});
+  }
+
+  public async setPayoutInstructions(
+    launcher_id: string,
+    payout_instructions: string
+  ): Promise<RpcResponse> {
+    return this.request<RpcResponse>("set_payout_instructions", {
+      launcher_id: launcher_id,
+      payout_instructions: payout_instructions
+    });
+  }
+
+  public async getPoolLoginLink(
+    launcher_id: string
+  ): Promise<LoginLinkResponse> {
+    return this.request<LoginLinkResponse>("get_pool_login_link", {
+      launcher_id: launcher_id
     });
   }
 }

--- a/src/types/Farmer/PoolConfig.ts
+++ b/src/types/Farmer/PoolConfig.ts
@@ -1,0 +1,9 @@
+export interface PoolConfig {
+  authentication_public_key: string;
+  launcher_id: string;
+  owner_public_key: string;
+  p2_singleton_puzzle_hash: string;
+  payout_instructions: string;
+  pool_url: string;
+  target_puzzle_hash: string;
+}

--- a/src/types/Farmer/PoolError.ts
+++ b/src/types/Farmer/PoolError.ts
@@ -1,0 +1,4 @@
+export interface PoolError {
+  error_code: number;
+  error_message: string;
+}

--- a/src/types/Farmer/PoolState.ts
+++ b/src/types/Farmer/PoolState.ts
@@ -1,0 +1,17 @@
+import { PoolConfig } from './PoolConfig';
+import { PoolError } from './PoolError';
+
+export interface PoolState {
+  authentication_token_timeout: number;
+  current_difficulty: number;
+  current_points: number;
+  next_farmer_update: number;
+  next_pool_info_update: number;
+  p2_singleton_puzzle_hash: string;
+  points_acknowledged_24h: number[][];
+  points_acknowledged_since_start: number;
+  points_found_24h: number[][];
+  points_found_since_start: number;
+  pool_config: PoolConfig;
+  pool_errors_24h: PoolError[];
+}

--- a/src/types/Farmer/RpcResponse.ts
+++ b/src/types/Farmer/RpcResponse.ts
@@ -1,6 +1,7 @@
 import { ProofOfSpace } from '../FullNode/ProofOfSpace';
 import { RpcResponse } from '../RpcResponse';
 import { SignagePoint } from './SignagePoint';
+import { PoolState } from './PoolState';
 
 export interface SignagePointResponse extends RpcResponse {
     signage_point: SignagePoint;
@@ -21,3 +22,11 @@ export interface RewardTargetResponse extends RpcResponse {
     have_pool_sk?: boolean
 }
 
+export interface PoolStateResponse extends RpcResponse {
+    pool_state: PoolState[];
+}
+
+
+export interface LoginLinkResponse extends RpcResponse {
+    login_link: string;
+}

--- a/test/farmer.spec.ts
+++ b/test/farmer.spec.ts
@@ -50,5 +50,42 @@ describe("Farmer", () => {
 
       expect(await farmer.setRewardTarget("fakeFarmerTarget", "fakePoolTarget")).toEqual("success");
     });
+
+    it("calls get_pool_state", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_pool_state", {})
+        .reply(200, "success");
+
+      expect(await farmer.getPoolState()).toEqual("success");
+    });
+
+    it("calls set_payout_instructions", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/set_payout_instructions", {
+          launcher_id: 'fakeLauncher',
+          payout_instructions: 'fakePayoutInstructions'
+        })
+        .reply(200, "success");
+
+      expect(await farmer.setPayoutInstructions(
+        'fakeLauncher',
+        'fakePayoutInstructions'
+      )).toEqual("success");
+    });
+
+    it("calls get_pool_login_link", async () => {
+      nock("https://localhost:8559")
+        .defaultReplyHeaders({ "access-control-allow-origin": "*" })
+        .post("/get_pool_login_link", {
+          launcher_id: 'fakeLauncher',
+        })
+        .reply(200, "success");
+
+      expect(await farmer.getPoolLoginLink(
+        'fakeLauncher'
+      )).toEqual("success");
+    });
   });
 });


### PR DESCRIPTION
Add Farmer Calls for pooling:
- `getPoolState()`
- `setPayoutInstructions(launcher_id: string, payout_instructions: string)`
- `getPoolLoginLink(launcher_id: string)`